### PR TITLE
Speed up minute index to session labels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ with-ignore-docstrings=1
 with-timer=1
 timer-top-n=15
 cover-package=trading_calendars
+logging-level=INFO
 
 [metadata]
 description-file = README.md

--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -844,11 +844,15 @@ class TradingCalendar(with_metaclass(ABCMeta)):
             next_open, next_close = self.schedule.iloc[prev_day + 1]
 
             raise ValueError(
-                "{} non-market minutes in minute_index_to_session_labels:\n"
-                "First Bad Minute: {}\n"
-                "Previous Session: {} -> {}"
-                "Next Session: {} -> {}"
-                .format(example, prev_open, prev_close, next_open, next_close)
+                "{num} non-market minutes in minute_index_to_session_labels:\n"
+                "First Bad Minute: {first_bad}\n"
+                "Previous Session: {prev_open} -> {prev_close}"
+                "Next Session: {next_open} -> {next_close}"
+                .format(
+                    num=mismatches.sum(),
+                    first_bad=example,
+                    prev_open=prev_open, prev_close=prev_close,
+                    next_open=next_open, next_close=next_close)
             )
 
         return self.schedule.index[prev_opens]


### PR DESCRIPTION
Instead of calling `map` of `self.minute_to_session_label`, implement a
vectorized version of `minute_index_to_session_labels` with
`direction="none"` using `searchsorted`.

On my machine, this is speeds up large lookups by a factor of over
300x.

Before:

```
In [4]: %time cal.minute_index_to_session_labels(cal.all_minutes)
CPU times: user 32.8 s, sys: 272 ms, total: 33.1 s
Wall time: 33 s
Out[4]:
DatetimeIndex(['1990-01-02', '1990-01-02', '1990-01-02', '1990-01-02',
               '1990-01-02', '1990-01-02', '1990-01-02', '1990-01-02',
               '1990-01-02', '1990-01-02',
               ...
               '2019-06-28', '2019-06-28', '2019-06-28', '2019-06-28',
               '2019-06-28', '2019-06-28', '2019-06-28', '2019-06-28',
               '2019-06-28', '2019-06-28'],
              dtype='datetime64[ns, UTC]', length=2887560, freq=None)
```

After:

```
In [4]: %time cal.minute_index_to_session_labels(cal.all_minutes)
CPU times: user 71.9 ms, sys: 23.9 ms, total: 95.8 ms
Wall time: 95.1 ms
Out[4]:
DatetimeIndex(['1990-01-02', '1990-01-02', '1990-01-02', '1990-01-02',
               '1990-01-02', '1990-01-02', '1990-01-02', '1990-01-02',
               '1990-01-02', '1990-01-02',
               ...
               '2019-06-28', '2019-06-28', '2019-06-28', '2019-06-28',
               '2019-06-28', '2019-06-28', '2019-06-28', '2019-06-28',
               '2019-06-28', '2019-06-28'],
              dtype='datetime64[ns, UTC]', length=2887560, freq=None)
```