### PR TITLE
MAINT: Simplify _special_dates.

### DIFF
--- a/trading_calendars/utils/pandas_utils.py
+++ b/trading_calendars/utils/pandas_utils.py
@@ -44,25 +44,3 @@ def days_at_time(days, t, tz, day_offset=0):
         seconds=t.second,
     )
     return (days + delta).tz_localize(tz).tz_convert('UTC')
-
-
-def series_from_records(records):
-    """Construct a Series from a list of tuples.
-
-    Parameters
-    ----------
-    records : list[tuple]
-        A list of tuples, with the first element in each tuple
-        corresponding to a Series index, and the second element in each
-        corresponding to Series values.
-
-    Returns
-    -------
-    pd.Series
-    """
-    df = pd.DataFrame.from_records(records, index=[0])
-
-    if df.empty:
-        return pd.Series()
-
-    return df[1]


### PR DESCRIPTION
@yankees714 I had a bit of a hard time following the new `_special_dates` implementation. Here's a take on an alternative that stays with pandas objects for more of the algorithm rather than round-tripping through lists of tuples.