### PR TITLE
BUG: Fix bug on python 3.6.

### DIFF
--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -964,7 +964,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
             return pd.Series([])
 
         result = pd.concat(merged).sort_index()
-        return result[(result >= start_date) & (result <= end_date)]
+        return result.loc[(result >= start_date) & (result <= end_date)]
 
     def _calculate_special_opens(self, start, end):
         return self._special_dates(


### PR DESCRIPTION
On python 3.6, pandas 0.18 gets very unhappy if you try to index a series with
a datetime-indexed series.