### PR TITLE
MAINT: bump pytz to 2018.6

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -12,6 +12,6 @@ parameterized==0.6.1
 pycodestyle==2.3.1
 pyflakes==1.6.0
 python-dateutil==2.7.3
-pytz==2018.4
+pytz==2018.6
 six==1.11.0
 toolz==0.9.0


### PR DESCRIPTION
Bumping pytz in order to get updates to Brazil's DST and
Ireland's standard time.