### PR TITLE
BLD: Don't install tests from trading-calendars package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - source activate testenv
   - python -m pip install --upgrade pip coveralls
   - python -m pip install -r etc/requirements.txt
+  - python -m pip freeze | sort
 
 script:
   - flake8 trading_calendars tests

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,8 @@ if __name__ == '__main__':
         url=URL,
         classifiers=classifiers,
         long_description=LONG_DESCRIPTION,
-        packages=find_packages(include='trading_calendars.*'),
+        packages=find_packages(
+            include=['trading_calendars', 'trading_calendars.*']
+        ),
         install_requires=reqs,
     )


### PR DESCRIPTION
This often leads to conflicts in namespacing where apps have a
top-level tests dir (or another errant lib does the same).

The `include` parameter expects a list of patterns. We were passing
the string `'trading_calendars.*'`, so one of the patterns was `'*'`
which matched all the directories.