### PR TITLE
BUG: Do not loop-back when count is greater than historical dates

### DIFF
--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -640,7 +640,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         """
         start_idx = self.schedule.index.get_loc(session_label)
         end_idx = start_idx + count
-
+        end_idx = max(0, end_idx)
         return self.all_sessions[
             min(start_idx, end_idx):max(start_idx, end_idx) + 1
         ]


### PR DESCRIPTION
Made sure that `end_idx` in `sessions_window` method is always positive so that it does not loop-back when indexing on all_sessions when the count/lookback period is greater than the length of total historical dates. More details in #124.