### PR TITLE
Fix pandas DeprecationWarning for empty series

### DIFF
--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -980,7 +980,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         merged = regular + ad_hoc
         if not merged:
             # Concat barfs if the input has length 0.
-            return pd.Series([])
+            return pd.Series([], dtype="object")
 
         result = pd.concat(merged).sort_index()
         return result.loc[(result >= start_date) & (result <= end_date)]

--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -980,7 +980,7 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         merged = regular + ad_hoc
         if not merged:
             # Concat barfs if the input has length 0.
-            return pd.Series([], dtype="object")
+            return pd.Series([], dtype="datetime64[ns, UTC]")
 
         result = pd.concat(merged).sort_index()
         return result.loc[(result >= start_date) & (result <= end_date)]


### PR DESCRIPTION
Initializing an empty pandas.Series without specifying a dtype will raise a
DeprecationWarning. Explicitly set the dtype to object for empty set
initialization.


> trading_calendar.py:983: DeprecationWarning: The default dtype for empty Series will be  'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
>    return pd.Series([])
