### PR TITLE
BLD: Add `test` to `extras_require`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,13 @@ if __name__ == '__main__':
             include=['trading_calendars', 'trading_calendars.*']
         ),
         install_requires=reqs,
+        extras_require={
+            "test": [
+                "flake8",
+                "nose",
+                "nose-ignore-docstring",
+                "nose-timer",
+                "parameterized",
+            ],
+        },
     )


### PR DESCRIPTION
Closes https://github.com/quantopian/trading_calendars/issues/143.

Ideally we'd change etc/requirements.txt to a lock file and use that as a constraint to install the `extras_require` in the GHA step.