### PR TITLE
Fix series equal assertion for issue 

### DIFF
--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -784,9 +784,9 @@ class ExchangeCalendarTestBase(object):
             self.answers.index[0],
             self.answers.index[-1],
         )
-
+        found_opens.index.freq = None
         pd.util.testing.assert_series_equal(
-            found_opens, self.answers['market_open'], check_freq=False
+            found_opens, self.answers['market_open']
         )
 
     def test_session_closes_in_range(self):
@@ -794,9 +794,9 @@ class ExchangeCalendarTestBase(object):
             self.answers.index[0],
             self.answers.index[-1],
         )
-
+        found_closes.index.freq = None
         pd.util.testing.assert_series_equal(
-            found_closes, self.answers['market_close'], check_freq=False
+            found_closes, self.answers['market_close']
         )
 
     def test_daylight_savings(self):

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -786,7 +786,7 @@ class ExchangeCalendarTestBase(object):
         )
 
         pd.util.testing.assert_series_equal(
-            found_opens, self.answers['market_open']
+            found_opens, self.answers['market_open'], check_freq=False
         )
 
     def test_session_closes_in_range(self):
@@ -796,7 +796,7 @@ class ExchangeCalendarTestBase(object):
         )
 
         pd.util.testing.assert_series_equal(
-            found_closes, self.answers['market_close']
+            found_closes, self.answers['market_close'], check_freq=False
         )
 
     def test_daylight_savings(self):


### PR DESCRIPTION
This is a fix for issue #145 

It turns out the problem is that TradingCalendar.schedule datetimeindex has the frequency 'C' but the answer key does not because that info is lost when the data frame is saved as CSV.

Now `nosetests tests\test_xnys_calendar.py` yields

```
[success] 47.93% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minute_to_session_label: 6.9389s
[success] 12.58% tests.test_xnys_calendar.XNYSCalendarTestCase.test_open_and_close_for_session: 1.8213s
[success] 11.51% tests.test_xnys_calendar.XNYSCalendarTestCase.test_next_prev_minute: 1.6660s
[success] 11.15% tests.test_xnys_calendar.XNYSCalendarTestCase.test_next_prev_open_close: 1.6139s
[success] 4.03% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minute_index_to_session_labels_0: 0.5833s
[success] 3.11% tests.test_xnys_calendar.XNYSCalendarTestCase.test_next_prev_session: 0.4506s
[success] 2.35% tests.test_xnys_calendar.XNYSCalendarTestCase.test_sanity_check_session_lengths: 0.3397s
[success] 2.17% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minute_index_to_session_labels_2: 0.3141s
[success] 1.99% tests.test_xnys_calendar.XNYSCalendarTestCase.test_is_open_on_minute: 0.2884s
[success] 1.83% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minute_index_to_session_labels_1: 0.2648s
[success] 0.97% tests.test_xnys_calendar.XNYSCalendarTestCase.test_start_end: 0.1411s
[success] 0.06% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minutes_for_period: 0.0089s
[success] 0.05% tests.test_xnys_calendar.XNYSCalendarTestCase.test_session_closes_in_range: 0.0078s
[success] 0.05% tests.test_xnys_calendar.XNYSCalendarTestCase.test_session_opens_in_range: 0.0077s
[success] 0.05% tests.test_xnys_calendar.XNYSCalendarTestCase.test_minutes_in_range: 0.0071s

Ran 27 tests in 15.080s
```