### PR TITLE
TST: Move off nose and on to pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,6 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8
-    - name: Test with nose
+    - name: Test with pytest
       run: |
-        nosetests tests
+        pytest tests

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -2,9 +2,7 @@
 configparser==3.5.0
 enum34==1.1.6
 flake8==3.7.9
-nose==1.3.7
-nose-ignore-docstring==0.2
-nose-timer==0.7.5
+pytest==6.0.1
 parameterized==0.6.1
 python-dateutil==2.7.3
 pytz==2019.3

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -2,7 +2,8 @@
 configparser==3.5.0
 enum34==1.1.6
 flake8==3.7.9
-pytest==6.0.1
+pytest==4.6.11;python_version<"3.5"
+pytest==6.0.1;python_version>"2.7"
 parameterized==0.6.1
 python-dateutil==2.7.3
 pytz==2019.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,3 @@
-[nosetests]
-verbosity=2
-detailed-errors=1
-with-ignore-docstrings=1
-with-timer=1
-timer-top-n=15
-cover-package=trading_calendars
-logging-level=INFO
-traverse-namespace=1
-
 [metadata]
 description-file = README.md
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 description-file = README.md
 license_file = LICENSE
 
-[tools:pytest]
+[tool:pytest]
 addopts = -v --durations=15
 
 # See the docstring in versioneer.py for instructions. Note that you must

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,9 @@
 description-file = README.md
 license_file = LICENSE
 
+[tools:pytest]
+addopts = -v --durations=15
+
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,7 @@ if __name__ == '__main__':
         extras_require={
             "test": [
                 "flake8",
-                "nose",
-                "nose-ignore-docstring",
-                "nose-timer",
+                "pytest",
                 "parameterized",
             ],
         },

--- a/tests/test_calendar_dispatcher.py
+++ b/tests/test_calendar_dispatcher.py
@@ -14,7 +14,7 @@ from trading_calendars.exchange_calendar_iepa import IEPAExchangeCalendar
 class CalendarAliasTestCase(TestCase):
 
     @classmethod
-    def setupClass(cls):
+    def setup_class(cls):
         # Make a calendar once so that we don't spend time in every test
         # instantiating calendars.
         cls.dispatcher_kwargs = dict(
@@ -26,18 +26,18 @@ class CalendarAliasTestCase(TestCase):
             },
         )
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dispatcher = TradingCalendarDispatcher(
             # Make copies here so that tests that mutate the dispatcher dicts
             # are isolated from one another.
             **{k: v.copy() for k, v in self.dispatcher_kwargs.items()}
         )
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.dispatcher = None
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.dispatcher_kwargs = None
 
     def test_follow_alias_chain(self):

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 
 import numpy as np
 import pandas as pd
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from pandas import read_csv
 from pandas import Timedelta
 from pandas.util.testing import assert_index_equal

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -61,11 +61,11 @@ class FakeCalendar(TradingCalendar):
 
 
 class CalendarRegistrationTestCase(TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.dummy_cal_type = FakeCalendar
         self.dispatcher = TradingCalendarDispatcher({}, {}, {})
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.dispatcher.clear_calendars()
 
     def test_register_calendar(self):
@@ -229,7 +229,7 @@ class ExchangeCalendarTestBase(object):
         )
 
     @classmethod
-    def setupClass(cls):
+    def setup_class(cls):
         cls.answers = cls.load_answer_key(cls.answer_key_filename)
 
         cls.start_date = cls.answers.index[0]
@@ -240,7 +240,7 @@ class ExchangeCalendarTestBase(object):
         cls.one_hour = pd.Timedelta(hours=1)
 
     @classmethod
-    def teardownClass(cls):
+    def teardown_class(cls):
         cls.calendar = None
         cls.answers = None
 

--- a/tests/test_xidx_calendar.py
+++ b/tests/test_xidx_calendar.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pandas as pd
 from pytz import UTC
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from .test_trading_calendar import NoDSTExchangeCalendarTestBase
 from trading_calendars.trading_calendar import WEEKENDS

--- a/tests/test_xjse_calendar.py
+++ b/tests/test_xjse_calendar.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pandas as pd
 from pytz import UTC
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from .test_trading_calendar import NoDSTExchangeCalendarTestBase
 from trading_calendars.trading_calendar import WEEKENDS

--- a/tests/test_xkar_calendar.py
+++ b/tests/test_xkar_calendar.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import pandas as pd
 from pytz import UTC
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from .test_trading_calendar import NoDSTExchangeCalendarTestBase
 from trading_calendars.trading_calendar import WEEKENDS


### PR DESCRIPTION
Closes https://github.com/quantopian/trading_calendars/issues/160

I didn't change any of the `self.assert*` code or move this from a class interface to a more `pytset.fixtures` interface. I'd like to do that after py2 gets dropped. 