### PR TITLE
TST: Improve our CI tests speed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,4 +56,4 @@ jobs:
         flake8
     - name: Test with pytest
       run: |
-        pytest tests
+        pytest tests -n auto --dist loadscope

--- a/etc/requirements_dev.in
+++ b/etc/requirements_dev.in
@@ -1,5 +1,8 @@
 flake8
+
 pytest
 pytest-benchmark
 parameterized
+pytest-xdist
+
 pip-tools

--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile --output-file=etc/requirements_locked.txt etc/requirements.in etc/requirements_dev.in
 #
+apipkg==1.5               # via execnet
 attrs==20.2.0             # via pytest
 click==7.1.2              # via pip-tools
+execnet==1.7.1            # via pytest-xdist
 flake8==3.8.4             # via -r etc/requirements_dev.in
 importlib-metadata==2.0.0  # via flake8, pluggy, pytest
 iniconfig==1.0.1          # via pytest
@@ -17,13 +19,15 @@ parameterized==0.7.4      # via -r etc/requirements_dev.in
 pip-tools==5.3.1          # via -r etc/requirements_dev.in
 pluggy==0.13.1            # via pytest
 py-cpuinfo==7.0.0         # via pytest-benchmark
-py==1.9.0                 # via pytest
+py==1.9.0                 # via pytest, pytest-forked
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest-benchmark==3.2.3   # via -r etc/requirements_dev.in
-pytest==6.1.1             # via -r etc/requirements_dev.in, pytest-benchmark
-python-dateutil==2.8.1    # via pandas
+pytest-forked==1.3.0      # via pytest-xdist
+pytest-xdist==2.1.0       # via -r etc/requirements_dev.in
+pytest==6.1.1             # via -r etc/requirements_dev.in, pytest-benchmark, pytest-forked, pytest-xdist
+python-dateutil==2.8.1    # via -r etc/requirements.in, pandas
 pytz==2020.1              # via -r etc/requirements.in, pandas
 six==1.15.0               # via -r etc/requirements.in, packaging, pip-tools, python-dateutil
 toml==0.10.1              # via pytest

--- a/etc/requirements_locked_old.txt
+++ b/etc/requirements_locked_old.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file=etc/requirements_locked_old.txt etc/requirements.in etc/requirements_dev.in
 #
+apipkg==1.5               # via execnet
 atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via pytest
 backports.functools-lru-cache==1.6.1  # via wcwidth
@@ -12,6 +13,7 @@ configparser==4.0.2       # via flake8, importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
 docutils==0.16            # via statistics
 enum34==1.1.10            # via flake8
+execnet==1.7.1            # via pytest-xdist
 flake8==3.8.4             # via -r etc/requirements_dev.in
 funcsigs==1.0.2           # via pytest
 functools32==3.2.3.post2  # via flake8
@@ -26,16 +28,18 @@ pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-benchmark
 pip-tools==5.3.1          # via -r etc/requirements_dev.in
 pluggy==0.13.1            # via pytest
 py-cpuinfo==7.0.0         # via pytest-benchmark
-py==1.9.0                 # via pytest
+py==1.9.0                 # via pytest, pytest-forked
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest-benchmark==3.2.3   # via -r etc/requirements_dev.in
-pytest==4.6.11            # via -r etc/requirements_dev.in, pytest-benchmark
-python-dateutil==2.8.1    # via pandas
+pytest-forked==1.3.0      # via pytest-xdist
+pytest-xdist==1.34.0      # via -r etc/requirements_dev.in
+pytest==4.6.11            # via -r etc/requirements_dev.in, pytest-benchmark, pytest-forked, pytest-xdist
+python-dateutil==2.8.1    # via -r etc/requirements.in, pandas
 pytz==2020.1              # via -r etc/requirements.in, pandas
 scandir==1.10.0           # via pathlib2
-six==1.15.0               # via more-itertools, packaging, pathlib2, pip-tools, pytest, python-dateutil
+six==1.15.0               # via -r etc/requirements.in, more-itertools, packaging, pathlib2, pip-tools, pytest, pytest-xdist, python-dateutil
 statistics==1.0.3.5       # via pytest-benchmark
 toolz==0.10.0             # via -r etc/requirements.in
 typing==3.7.4.3           # via flake8

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ if __name__ == '__main__':
                 "pytest",
                 "pytest-benchmark",
                 "parameterized",
+                "pytest-xdist",
             ],
         },
     )

--- a/tests/test_always_open.py
+++ b/tests/test_always_open.py
@@ -1,11 +1,13 @@
 from unittest import TestCase
 
 import pandas as pd
-from pandas.util.testing import assert_index_equal
 from pytz import UTC
 
 from trading_calendars.always_open import AlwaysOpenCalendar
+from trading_calendars.utils.pandas_utils import testing
 from .test_trading_calendar import ExchangeCalendarTestBase
+
+assert_index_equal = testing.assert_index_equal
 
 
 class AlwaysOpenTestCase(ExchangeCalendarTestBase, TestCase):

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -396,17 +396,16 @@ class ExchangeCalendarTestBase(object):
                 )
 
     def test_minute_to_session_label(self):
-        for idx, info in enumerate(self.answers[1:-2].iterrows()):
-            session_label = info[1].name
-            open_minute = info[1].iloc[0]
-            close_minute = info[1].iloc[1]
+        for idx, (session_label, open_minute, close_minute) in enumerate(
+                self.answers.iloc[1:-2].itertuples(name=None)
+        ):
             hour_into_session = open_minute + self.one_hour
 
             minute_before_session = open_minute - self.one_minute
             minute_after_session = close_minute + self.one_minute
 
-            next_session_label = self.answers.iloc[idx + 2].name
-            previous_session_label = self.answers.iloc[idx].name
+            next_session_label = self.answers.index[idx + 2]
+            previous_session_label = self.answers.index[idx]
 
             # verify that minutes inside a session resolve correctly
             minutes_that_resolve_to_this_session = [
@@ -803,10 +802,8 @@ class ExchangeCalendarTestBase(object):
         self.assertEqual(one_day_distance, 1)
 
     def test_open_and_close_for_session(self):
-        for index, row in self.answers.iterrows():
-            session_label = row.name
-            open_answer = row.iloc[0]
-            close_answer = row.iloc[1]
+        for session_label, open_answer, close_answer in \
+                self.answers.itertuples(name=None):
 
             found_open, found_close = \
                 self.calendar.open_and_close_for_session(session_label)

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -25,7 +25,6 @@ import pandas as pd
 from parameterized import parameterized
 from pandas import read_csv
 from pandas import Timedelta
-from pandas.util.testing import assert_index_equal
 from pytz import timezone
 from pytz import UTC
 from toolz import concat
@@ -34,7 +33,6 @@ from trading_calendars.errors import (
     CalendarNameCollision,
     InvalidCalendarName,
 )
-
 from trading_calendars import (
     get_calendar,
 )
@@ -47,6 +45,9 @@ from trading_calendars.trading_calendar import (
     days_at_time,
     TradingCalendar,
 )
+from trading_calendars.utils.pandas_utils import testing
+
+assert_index_equal = testing.assert_index_equal
 
 
 class FakeCalendar(TradingCalendar):
@@ -825,7 +826,7 @@ class ExchangeCalendarTestBase(object):
             self.answers.index[-1],
         )
         found_opens.index.freq = None
-        pd.util.testing.assert_series_equal(
+        testing.assert_series_equal(
             found_opens, self.answers['market_open']
         )
 
@@ -835,7 +836,7 @@ class ExchangeCalendarTestBase(object):
             self.answers.index[-1],
         )
         found_closes.index.freq = None
-        pd.util.testing.assert_series_equal(
+        testing.assert_series_equal(
             found_closes, self.answers['market_close']
         )
 

--- a/tests/test_weekday_calendar.py
+++ b/tests/test_weekday_calendar.py
@@ -1,11 +1,13 @@
 from unittest import TestCase
 
 import pandas as pd
-from pandas.util.testing import assert_index_equal
 from pytz import UTC
 
 from trading_calendars.weekday_calendar import WeekdayCalendar
+from trading_calendars.utils.pandas_utils import testing
 from .test_trading_calendar import ExchangeCalendarTestBase
+
+assert_index_equal = testing.assert_index_equal
 
 
 class WeekdayCalendarTestCase(ExchangeCalendarTestBase, TestCase):

--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -193,11 +193,11 @@ class TradingCalendar(with_metaclass(ABCMeta)):
         self.last_trading_session = _all_days[-1]
 
         self._late_opens = pd.DatetimeIndex(
-            _special_opens.map(self.minute_to_session_label)
+            _special_opens.map(self.minute_index_to_session_labels)
         )
 
         self._early_closes = pd.DatetimeIndex(
-            _special_closes.map(self.minute_to_session_label)
+            _special_closes.map(self.minute_index_to_session_labels)
         )
 
     @lazyval

--- a/trading_calendars/utils/pandas_utils.py
+++ b/trading_calendars/utils/pandas_utils.py
@@ -65,3 +65,9 @@ def vectorized_sunday_to_monday(dtix):
     values = dtix.values.copy()
     values[dtix.weekday == 6] += np.timedelta64(1, 'D')
     return pd.DatetimeIndex(values)
+
+
+try:
+    from pandas import testing  # noqa: rexport
+except ImportError:
+    from pandas.util import testing  # noqa: rexport


### PR DESCRIPTION
- Uses faster pandas methods for iteration
- Parallelizes tests across CPUs
- Sped up calendar construction for special opens and closes
- Removed a deprecation warning

An example (macos-latest, 3.8):
"Test with pytest" (before): 22m36s
"Test with pytest" (after): 3m54s