### PR TITLE
ENH: Add rules for XTAE holidays.

### DIFF
--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -4,3 +4,4 @@ python-dateutil
 pytz
 six
 toolz
+pyluach

--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -1,7 +1,7 @@
 numpy
 pandas
+pyluach
 python-dateutil
 pytz
 six
 toolz
-pyluach

--- a/etc/requirements_locked.txt
+++ b/etc/requirements_locked.txt
@@ -22,6 +22,7 @@ py-cpuinfo==7.0.0         # via pytest-benchmark
 py==1.9.0                 # via pytest, pytest-forked
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
+pyluach==1.2.1            # via -r etc/requirements.in
 pyparsing==2.4.7          # via packaging
 pytest-benchmark==3.2.3   # via -r etc/requirements_dev.in
 pytest-forked==1.3.0      # via pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ classifiers = [
 reqs = [
     "numpy",
     "pandas",
+    "pyluach",
     "python-dateutil",
     "pytz",
     "six",

--- a/trading_calendars/exchange_calendar_xtae.py
+++ b/trading_calendars/exchange_calendar_xtae.py
@@ -17,12 +17,11 @@ from datetime import time
 import pandas as pd
 from pytz import timezone, UTC
 from .trading_calendar import TradingCalendar, HolidayCalendar
-from .tase_holidays import (Purim, ShushanPurim, PassoverEve,
-                            Passover, Passover2Eve, Passover2, PentecostEve,
-                            Pentecost, FastDay, MemorialDay, IndependenceDay,
-                            NewYearsEve, NewYear, NewYear2, YomKippurEve,
-                            YomKippur, SukkothEve, Sukkoth, SimchatTorahEve,
-                            SimchatTorah)
+from .tase_holidays import (Purim, PassoverEve, Passover, Passover2Eve,
+                            Passover2, PentecostEve, Pentecost, FastDay,
+                            MemorialDay, IndependenceDay, NewYearsEve, NewYear,
+                            NewYear2, YomKippurEve, YomKippur, SukkothEve,
+                            Sukkoth, SimchatTorahEve, SimchatTorah)
 
 # All holidays are defined as ad-hoc holidays for each year since there is
 # currently no support for Hebrew calendar holiday rules in pandas.
@@ -40,7 +39,6 @@ class XTAEExchangeCalendar(TradingCalendar):
 
     Regularly-Observed Holidays (not necessarily in order):
     - Purim
-    - Shushan Purim
     - Passover Eve
     - Passover
     - Passover II Eve
@@ -87,7 +85,6 @@ class XTAEExchangeCalendar(TradingCalendar):
     def regular_holidays(self):
         return HolidayCalendar([
             Purim,
-            ShushanPurim,
             PassoverEve,
             Passover,
             Passover2Eve,

--- a/trading_calendars/exchange_calendar_xtae.py
+++ b/trading_calendars/exchange_calendar_xtae.py
@@ -118,7 +118,7 @@ class XTAEExchangeCalendar(TradingCalendar):
             pd.Timestamp('2020-03-02', tz='Asia/Jerusalem'),
             # 2021
             # Election Day
-            pd.Timestamp('2020-03-23', tz='Asia/Jerusalem')
+            pd.Timestamp('2021-03-23', tz='Asia/Jerusalem')
         ]
 
     @property

--- a/trading_calendars/exchange_calendar_xtae.py
+++ b/trading_calendars/exchange_calendar_xtae.py
@@ -116,6 +116,9 @@ class XTAEExchangeCalendar(TradingCalendar):
             # 2020
             # Election Day
             pd.Timestamp('2020-03-02', tz='Asia/Jerusalem'),
+            # 2021
+            # Election Day
+            pd.Timestamp('2020-03-23', tz='Asia/Jerusalem')
         ]
 
     @property

--- a/trading_calendars/exchange_calendar_xtae.py
+++ b/trading_calendars/exchange_calendar_xtae.py
@@ -16,7 +16,13 @@
 from datetime import time
 import pandas as pd
 from pytz import timezone, UTC
-from .trading_calendar import TradingCalendar
+from .trading_calendar import TradingCalendar, HolidayCalendar
+from .tase_holidays import (Purim, ShushanPurim, PassoverEve,
+                            Passover, Passover2Eve, Passover2, PentecostEve,
+                            Pentecost, FastDay, MemorialDay, IndependenceDay,
+                            NewYearsEve, NewYear, NewYear2, YomKippurEve,
+                            YomKippur, SukkothEve, Sukkoth, SimchatTorahEve,
+                            SimchatTorah)
 
 # All holidays are defined as ad-hoc holidays for each year since there is
 # currently no support for Hebrew calendar holiday rules in pandas.
@@ -34,24 +40,25 @@ class XTAEExchangeCalendar(TradingCalendar):
 
     Regularly-Observed Holidays (not necessarily in order):
     - Purim
-    - Passover_I_Eve
-    - Passover_I
-    - Passover_II_Eve
-    - Passover_II
-    - Independence_Day
-    - Yom_HaZikaron
-    - Shavuot_Eve
-    - Shavuot
-    - Tisha_beAv
-    - Jewish_New_Year_Eve
-    - Jewish_New_Year_I
-    - Jewish_New_Year_II
-    - Yom_Kippur_Eve
-    - Yom_Kippur
-    - Sukkoth_Eve
+    - Shushan Purim
+    - Passover Eve
+    - Passover
+    - Passover II Eve
+    - Passover II
+    - Memorial Day
+    - Independence Day
+    - Pentecost Eve
+    - Pentecost
+    - Tisha B'Av
+    - New Year's Eve
+    - New Year
+    - New Year II
+    - Yom Kippur Eve
+    - Yom Kippur
+    - Sukkoth Eve
     - Sukkoth
-    - Simchat_Tora_Eve
-    - Simchat_Tora
+    - Simchat Torah Eve
+    - Simchat Torah
 
     Note these dates are only checked against 2019-2023.
 
@@ -77,181 +84,41 @@ class XTAEExchangeCalendar(TradingCalendar):
     )
 
     @property
+    def regular_holidays(self):
+        return HolidayCalendar([
+            Purim,
+            ShushanPurim,
+            PassoverEve,
+            Passover,
+            Passover2Eve,
+            Passover2,
+            MemorialDay,
+            IndependenceDay,
+            PentecostEve,
+            Pentecost,
+            FastDay,
+            NewYearsEve,
+            NewYear,
+            NewYear2,
+            YomKippurEve,
+            YomKippur,
+            SukkothEve,
+            Sukkoth,
+            SimchatTorahEve,
+            SimchatTorah
+        ])
+
+    @property
     def adhoc_holidays(self):
         return [
             # 2019
-            # Purim
-            pd.Timestamp('2019-03-21', tz='Asia/Jerusalem'),
             # Election Day
             pd.Timestamp('2019-04-09', tz='Asia/Jerusalem'),
-            # Passover II Eve
-            pd.Timestamp('2019-04-25', tz='Asia/Jerusalem'),
-            # Passover II
-            pd.Timestamp('2019-04-26', tz='Asia/Jerusalem'),
-            # Memorial Day
-            pd.Timestamp('2019-05-08', tz='Asia/Jerusalem'),
-            # Independence Day
-            pd.Timestamp('2019-05-09', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot)
-            pd.Timestamp('2019-06-09', tz='Asia/Jerusalem'),
-            # Fast Day
-            pd.Timestamp('2019-08-11', tz='Asia/Jerusalem'),
             # Election Day
             pd.Timestamp('2019-09-17', tz='Asia/Jerusalem'),
-            # Jewish New Year Eve
-            pd.Timestamp('2019-09-29', tz='Asia/Jerusalem'),
-            # Jewish New Year I
-            pd.Timestamp('2019-09-30', tz='Asia/Jerusalem'),
-            # Jewish New Year II
-            pd.Timestamp('2019-10-01', tz='Asia/Jerusalem'),
-            # Yom Kiuppur Eve
-            pd.Timestamp('2019-10-08', tz='Asia/Jerusalem'),
-            # Yom Kippur
-            pd.Timestamp('2019-10-09', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth) Eve
-            pd.Timestamp('2019-10-13', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles
-            pd.Timestamp('2019-10-14', tz='Asia/Jerusalem'),
-            # Rejoicing of the Law (Simchat Tora) Eve
-            pd.Timestamp('2019-10-20', tz='Asia/Jerusalem'),
-            # Rejoicing of the Law
-            pd.Timestamp('2019-10-21', tz='Asia/Jerusalem'),
             # 2020
             # Election Day
             pd.Timestamp('2020-03-02', tz='Asia/Jerusalem'),
-            # Purim
-            pd.Timestamp('2020-03-10', tz='Asia/Jerusalem'),
-            # Passover I Eve
-            pd.Timestamp('2020-04-08', tz='Asia/Jerusalem'),
-            # Passover I
-            pd.Timestamp('2020-04-09', tz='Asia/Jerusalem'),
-            # Passover II Eve
-            pd.Timestamp('2020-04-14', tz='Asia/Jerusalem'),
-            # Passover II
-            pd.Timestamp('2020-04-15', tz='Asia/Jerusalem'),
-            # Memorial Day
-            pd.Timestamp('2020-04-28', tz='Asia/Jerusalem'),
-            # Independence Day
-            pd.Timestamp('2020-04-29', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot) Eve
-            pd.Timestamp('2020-05-28', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot)
-            pd.Timestamp('2020-05-29', tz='Asia/Jerusalem'),
-            # Fast Day
-            pd.Timestamp('2020-07-30', tz='Asia/Jerusalem'),
-            # Jewesh New Year II
-            pd.Timestamp('2020-09-20', tz='Asia/Jerusalem'),
-            # Yom Kippur Eve
-            pd.Timestamp('2020-09-27', tz='Asia/Jerusalem'),
-            # Yom Kippur
-            pd.Timestamp('2020-09-28', tz='Asia/Jerusalem'),
-            # 2021
-            # Purim
-            pd.Timestamp('2021-02-26', tz='Asia/Jerusalem'),
-            # Passover I
-            pd.Timestamp('2021-03-28', tz='Asia/Jerusalem'),
-            # Passover II Eve
-            pd.Timestamp('2021-04-02', tz='Asia/Jerusalem'),
-            # Memorial Day
-            pd.Timestamp('2021-04-14', tz='Asia/Jerusalem'),
-            # Independence Day
-            pd.Timestamp('2021-04-15', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot) Eve
-            pd.Timestamp('2021-05-16', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot)
-            pd.Timestamp('2021-05-17', tz='Asia/Jerusalem'),
-            # Fast Day
-            pd.Timestamp('2021-07-18', tz='Asia/Jerusalem'),
-            # Jewesh New Year Eve
-            pd.Timestamp('2021-09-06', tz='Asia/Jerusalem'),
-            # Jewesh New Year I
-            pd.Timestamp('2021-09-07', tz='Asia/Jerusalem'),
-            # Jewesh New Year II
-            pd.Timestamp('2021-09-08', tz='Asia/Jerusalem'),
-            # Yom Kippur Eve
-            pd.Timestamp('2021-09-15', tz='Asia/Jerusalem'),
-            # Yom Kippur
-            pd.Timestamp('2021-09-16', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth) Eve
-            pd.Timestamp('2021-09-20', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth)
-            pd.Timestamp('2021-09-21', tz='Asia/Jerusalem'),
-            # Recoicing of the Law (Simchat Tora) Eve
-            pd.Timestamp('2021-09-27', tz='Asia/Jerusalem'),
-            # Recoicing of the Law (Simchat Tora)
-            pd.Timestamp('2021-09-28', tz='Asia/Jerusalem'),
-            # 2022
-            # Purim
-            pd.Timestamp('2022-03-17', tz='Asia/Jerusalem'),
-            # Shushan Purim
-            pd.Timestamp('2022-03-18', tz='Asia/Jerusalem'),
-            # Passover Eve
-            pd.Timestamp('2022-04-15', tz='Asia/Jerusalem'),
-            # Passover II Eve
-            pd.Timestamp('2022-04-21', tz='Asia/Jerusalem'),
-            # Passover II
-            pd.Timestamp('2022-04-22', tz='Asia/Jerusalem'),
-            # Memorial Day (moved up)
-            pd.Timestamp('2022-05-04', tz='Asia/Jerusalem'),
-            # Independence Day
-            pd.Timestamp('2022-05-05', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot)
-            pd.Timestamp('2022-06-05', tz='Asia/Jerusalem'),
-            # Fast Day (postponed)
-            pd.Timestamp('2022-08-07', tz='Asia/Jerusalem'),
-            # Jewish New Year Eve
-            pd.Timestamp('2022-09-25', tz='Asia/Jerusalem'),
-            # Jewish New Year I
-            pd.Timestamp('2022-09-26', tz='Asia/Jerusalem'),
-            # Jewish New Year II
-            pd.Timestamp('2022-09-27', tz='Asia/Jerusalem'),
-            # Yom Kippur Eve
-            pd.Timestamp('2022-10-04', tz='Asia/Jerusalem'),
-            # Yom Kippur
-            pd.Timestamp('2022-10-05', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth) Eve
-            pd.Timestamp('2022-10-09', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth)
-            pd.Timestamp('2022-10-10', tz='Asia/Jerusalem'),
-            # Rejoicing of the Law (Simchat Tora) Eve
-            pd.Timestamp('2022-10-16', tz='Asia/Jerusalem'),
-            # Rejoicing of the Law (Simchat Tora)
-            pd.Timestamp('2022-10-17', tz='Asia/Jerusalem'),
-            # 2023
-            # Purim
-            pd.Timestamp('2023-03-07', tz='Asia/Jerusalem'),
-            # Shushan Purim
-            pd.Timestamp('2023-03-08', tz='Asia/Jerusalem'),
-            # Passover Eve
-            pd.Timestamp('2023-04-05', tz='Asia/Jerusalem'),
-            # Passover
-            pd.Timestamp('2023-04-06', tz='Asia/Jerusalem'),
-            # Passover II Eve
-            pd.Timestamp('2023-04-11', tz='Asia/Jerusalem'),
-            # Passover II
-            pd.Timestamp('2023-04-12', tz='Asia/Jerusalem'),
-            # Memorial Day
-            pd.Timestamp('2023-04-25', tz='Asia/Jerusalem'),
-            # Independence Day
-            pd.Timestamp('2023-04-26', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot) Eve
-            pd.Timestamp('2023-05-25', tz='Asia/Jerusalem'),
-            # Pentecost (Shavuot)
-            pd.Timestamp('2023-05-26', tz='Asia/Jerusalem'),
-            # Fast Day
-            pd.Timestamp('2023-07-27', tz='Asia/Jerusalem'),
-            # Jewish New Year Eve
-            pd.Timestamp('2023-09-15', tz='Asia/Jerusalem'),
-            # Jewish New Year II
-            pd.Timestamp('2023-09-17', tz='Asia/Jerusalem'),
-            # Yom Kippur Eve
-            pd.Timestamp('2023-09-24', tz='Asia/Jerusalem'),
-            # Yom Kippur
-            pd.Timestamp('2023-09-25', tz='Asia/Jerusalem'),
-            # Feast of Tabernacles (Sukkoth) Eve
-            pd.Timestamp('2023-09-29', tz='Asia/Jerusalem'),
-            # Rejoicing of the Law (Simchat Tora) Eve
-            pd.Timestamp('2023-10-06', tz='Asia/Jerusalem'),
         ]
 
     @property

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -1,0 +1,338 @@
+from datetime import datetime, date
+from pyluach import dates, hebrewcal
+from pandas.tseries.holiday import Holiday, Day
+from pandas._libs.tslibs.offsets import apply_wraps, Easter
+from pandas._libs.tslibs.conversion import localize_pydatetime
+from pandas._libs.tslibs.timestamps import _Timestamp
+
+# Auxiliary functions to get Hebrew dates for holidays observed by TASE for a
+# given Hebrew calendar year. These are just the raw dates with no adjustments
+# applied.
+#
+# Note: pyluach uses the biblical month numbering scheme where the year is
+# incremented when moving from the month of Elul (6) to Tishrei (7). See also
+# https://en.wikipedia.org/wiki/Hebrew_calendar.
+
+
+def _purim(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Purim in the given Hebrew year.
+    """
+    # Purim is observed in Adar (12), or Adar II (13) if in a leap year.
+    return dates.HebrewDate(year.year, 13 if year.leap else 12, 14)
+
+
+def _passover(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for the first day of Passover in the given Hebrew
+    year.
+    """
+    return dates.HebrewDate(year.year, 1, 15)
+
+
+def _memorial_day(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Memorial Day in the given Hebrew year.
+
+    Note: Independence Day is always celebrated the following day.
+    """
+    return dates.HebrewDate(year.year, 2, 4)
+
+
+def _pentecost(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Pentecost in the given Hebrew year.
+    """
+    return dates.HebrewDate(year.year, 3, 6)
+
+
+def _fast_day(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Tisha B'Av in the given Hebrew year.
+    """
+    return dates.HebrewDate(year.year, 5, 9)
+
+
+def _new_year(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for the first day of a new year in the given Hebrew
+    year.
+    """
+    return dates.HebrewDate(year.year, 7, 1)
+
+
+def _yom_kippur(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Yom Kippur in the given Hebrew year.
+    """
+    return dates.HebrewDate(year.year, 7, 10)
+
+
+def _sukkoth(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Sukkoth in the given Hebrew year.
+    """
+    return dates.HebrewDate(year.year, 7, 15)
+
+
+def _simchat_torah(year: hebrewcal.Year) -> dates.HebrewDate:
+    """
+    Return the Hebrew date for Simchat Torah in the given Hebrew year.
+    """
+    return dates.HebrewDate(year.year, 7, 22)
+
+
+def _hebrew_year(year: int) -> hebrewcal.Year:
+    """
+    Return the Hebrew calendar year that corresponds to 1st January of the
+    given Gregorian calendar year.
+
+    1st January of any Gregorian calendar year, say x, always falls into the
+    month of Tevet (10) or Shevat (11) of some Hebrew year f(x). Also, we have
+    f(x+1) = f(x) + 1, so that any year in the Gregorian calendar always
+    overlaps with two consecutive years in the Hebrew calendar and vice versa.
+    """
+    return hebrewcal.Year(dates.GregorianDate(year, 1, 1).to_heb().year)
+
+
+# Auxilliary functions to calculate Gregorian dates for holidays observed by
+# TASE for a given Gregorian calendar year. Adjustments are also applied.
+
+
+def purim(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Purim in the given Gregorian calendar year.
+    """
+    return _purim(_hebrew_year(year)).to_greg()
+
+
+def passover(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for the first day of Passover in the given
+    Gregorian calendar year.
+    """
+    return _passover(_hebrew_year(year)).to_greg()
+
+
+def memorial_day(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Memorial Day in the given Gregorian calendar
+    year.
+    """
+
+    # Regular Memorial Day date.
+    d = _memorial_day(_hebrew_year(year)).to_greg()
+
+    # Reschedule to avoid Sabbath desecration, maybe.
+    if d.isoweekday() == 4:
+        # Falls on a Thursday, so Independency Day falls on the Friday.
+        # Moved down by one day.
+        return d - 1
+    elif d.isoweekday() == 5:
+        # Falls on a Friday, so Independence Day falls on the Saturday.
+        # Moved down by two days.
+        return d - 2
+    elif d.isoweekday() == 6:
+        # Falls on a Saturday, therefore moved up by one day.
+        return d + 1
+    else:
+        return d
+
+
+def pentecost(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Pentecost in the given Gregorian calendar
+    year.
+    """
+    return _pentecost(_hebrew_year(year)).to_greg()
+
+
+def fast_day(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Tisha B'Av in the given Gregorian calendar
+    year.
+    """
+    d = _fast_day(_hebrew_year(year)).to_greg()
+
+    # Reschedule if it falls on Sabbath (Saturday), maybe.
+    if d.isoweekday() == 6:
+        # Falls on a Saturday, therefore moved up by one day.
+        return d + 1
+    else:
+        return d
+
+
+def new_year(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for the first day of a new year in the given
+    Gregorian calendar year.
+    """
+    return _new_year(_hebrew_year(year + 1)).to_greg()
+
+
+def yom_kippur(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Yom Kippur in the given Gregorian calendar
+    year.
+    """
+    return _yom_kippur(_hebrew_year(year + 1)).to_greg()
+
+
+def sukkoth(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Sukkoth in the given Gregorian calendar year.
+    """
+    return _sukkoth(_hebrew_year(year + 1)).to_greg()
+
+
+def simchat_torah(year: int) -> dates.GregorianDate:
+    """
+    Return the Gregorian date for Simchat Torah in the given Gregorian calendar
+    year.
+    """
+    return _simchat_torah(_hebrew_year(year + 1)).to_greg()
+
+
+def _is_normalized(dt: datetime):
+    if dt.hour != 0 or dt.minute != 0 or dt.second != 0 or dt.microsecond != 0:
+        # Regardless of whether dt is datetime vs Timestamp
+        return False
+    if isinstance(dt, _Timestamp):
+        return dt.nanosecond == 0
+    return True
+
+
+class _HolidayOffset(Easter):
+    """
+    Auxiliary class for DateOffset instances for the different holidays.
+    """
+
+    @property
+    def holiday(self):
+        """
+        Return the Gregorian date for the holiday in a given Gregorian calendar
+        year.
+        """
+        pass
+
+    @apply_wraps
+    def apply(self, other: datetime) -> datetime:
+        current = self.holiday(other.year)
+        current = datetime(current.year, current.month, current.day)
+        current = localize_pydatetime(current, other.tzinfo)
+
+        n = self.n
+        if n >= 0 and other < current:
+            n -= 1
+        elif n < 0 and other > current:
+            n += 1
+        # TODO: Why does this handle the 0 case the opposite of others?
+
+        # NOTE: self.holiday a dates.GregorianDate so we have to convert to
+        # type of other
+        new = self.holiday(other.year + n)
+        new = datetime(
+            new.year,
+            new.month,
+            new.day,
+            other.hour,
+            other.minute,
+            other.second,
+            other.microsecond,
+        )
+        return new
+
+    def is_on_offset(self, dt: datetime) -> bool:
+        if self.normalize and not _is_normalized(dt):
+            return False
+        return date(dt.year, dt.month, dt.day) == self.holiday(dt.year)
+
+
+# DateOffset subclasses for holidays observed by TASE.
+
+class _Purim(_HolidayOffset):
+    @property
+    def holiday(self):
+        return purim
+
+
+class _Passover(_HolidayOffset):
+    @property
+    def holiday(self):
+        return passover
+
+
+class _MemorialDay(_HolidayOffset):
+    @property
+    def holiday(self):
+        return memorial_day
+
+
+class _Pentecost(_HolidayOffset):
+    @property
+    def holiday(self):
+        return pentecost
+
+
+class _FastDay(_HolidayOffset):
+    @property
+    def holiday(self):
+        return fast_day
+
+
+class _NewYear(_HolidayOffset):
+    @property
+    def holiday(self):
+        return new_year
+
+
+class _YomKippur(_HolidayOffset):
+    @property
+    def holiday(self):
+        return yom_kippur
+
+
+class _Sukkoth(_HolidayOffset):
+    @property
+    def holiday(self):
+        return sukkoth
+
+
+class _SimchatTorah(_HolidayOffset):
+    @property
+    def holiday(self):
+        return simchat_torah
+
+
+# Holiday instances for holidays observed by TASE.
+Purim = Holiday("Purim", month=1, day=1, offset=[_Purim()])
+ShushanPurim = Holiday("Shushan Purim", month=1, day=1,
+                       offset=[_Purim(), Day(1)], start_date='2022-01-01')
+PassoverEve = Holiday("Passover Eve", month=1, day=1,
+                      offset=[_Passover(), Day(-1)])
+Passover = Holiday("Passover", month=1, day=1, offset=[_Passover()])
+Passover2Eve = Holiday("Passover II Eve", month=1, day=1,
+                       offset=[_Passover(), Day(5)])
+Passover2 = Holiday("Passover II", month=1, day=1,
+                    offset=[_Passover(), Day(6)])
+PentecostEve = Holiday("Pentecost Eve", month=1, day=1,
+                       offset=[_Pentecost(), Day(-1)])
+Pentecost = Holiday("Pentecost", month=1, day=1, offset=[_Pentecost()])
+FastDay = Holiday("Tisha B'Av", month=1, day=1, offset=[_FastDay()])
+MemorialDay = Holiday("Memorial Day", month=1, day=1, offset=[_MemorialDay()])
+IndependenceDay = Holiday("Independence Day", month=1, day=1,
+                          offset=[_MemorialDay(), Day(1)])
+NewYearsEve = Holiday("New Year's Eve", month=1, day=1,
+                      offset=[_NewYear(), Day(-1)])
+NewYear = Holiday("New Year", month=1, day=1, offset=[_NewYear()])
+NewYear2 = Holiday("New Year II", month=1, day=1, offset=[_NewYear(), Day(1)])
+YomKippurEve = Holiday("Yom Kippur Eve", month=1, day=1,
+                       offset=[_YomKippur(), Day(-1)])
+YomKippur = Holiday("Yom Kippur", month=1, day=1, offset=[_YomKippur()])
+SukkothEve = Holiday("Sukkoth Eve", month=1, day=1,
+                     offset=[_Sukkoth(), Day(-1)])
+Sukkoth = Holiday("Sukkoth", month=1, day=1, offset=[_Sukkoth()])
+SimchatTorahEve = Holiday("Simchat Torah Eve", month=1, day=1,
+                          offset=[_SimchatTorah(), Day(-1)])
+SimchatTorah = Holiday("Simchat Torah", month=1, day=1,
+                       offset=[_SimchatTorah()])

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -323,8 +323,6 @@ class _SimchatTorah(_HolidayOffset):
 
 # Holiday instances for holidays observed by TASE.
 Purim = Holiday("Purim", month=1, day=1, offset=[_Purim()])
-ShushanPurim = Holiday("Shushan Purim", month=1, day=1,
-                       offset=[_Purim(), Day(1)], start_date='2022-01-01')
 PassoverEve = Holiday("Passover Eve", month=1, day=1,
                       offset=[_Passover(), Day(-1)])
 Passover = Holiday("Passover", month=1, day=1, offset=[_Passover()])

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -118,7 +118,7 @@ def purim(year):
     """
     Return the Gregorian date for Purim in the given Gregorian calendar year.
     """
-    return _purim(_hebrew_year(year)).to_greg()
+    return _purim(_hebrew_year(year)).to_greg().to_pydate()
 
 
 def passover(year):
@@ -126,7 +126,7 @@ def passover(year):
     Return the Gregorian date for the first day of Passover in the given
     Gregorian calendar year.
     """
-    return _passover(_hebrew_year(year)).to_greg()
+    return _passover(_hebrew_year(year)).to_greg().to_pydate()
 
 
 def memorial_day(year):
@@ -136,7 +136,7 @@ def memorial_day(year):
     """
 
     # Regular Memorial Day date.
-    d = _memorial_day(_hebrew_year(year)).to_greg()
+    d = _memorial_day(_hebrew_year(year)).to_greg().to_pydate()
 
     # Reschedule to avoid Sabbath desecration, maybe.
     if d.isoweekday() == 4:
@@ -159,7 +159,7 @@ def pentecost(year):
     Return the Gregorian date for Pentecost in the given Gregorian calendar
     year.
     """
-    return _pentecost(_hebrew_year(year)).to_greg()
+    return _pentecost(_hebrew_year(year)).to_greg().to_pydate()
 
 
 def fast_day(year):
@@ -167,7 +167,7 @@ def fast_day(year):
     Return the Gregorian date for Tisha B'Av in the given Gregorian calendar
     year.
     """
-    d = _fast_day(_hebrew_year(year)).to_greg()
+    d = _fast_day(_hebrew_year(year)).to_greg().to_pydate()
 
     # Reschedule if it falls on Sabbath (Saturday), maybe.
     if d.isoweekday() == 6:
@@ -182,7 +182,7 @@ def new_year(year):
     Return the Gregorian date for the first day of a new year in the given
     Gregorian calendar year.
     """
-    return _new_year(_hebrew_year(year + 1)).to_greg()
+    return _new_year(_hebrew_year(year + 1)).to_greg().to_pydate()
 
 
 def yom_kippur(year):
@@ -190,14 +190,14 @@ def yom_kippur(year):
     Return the Gregorian date for Yom Kippur in the given Gregorian calendar
     year.
     """
-    return _yom_kippur(_hebrew_year(year + 1)).to_greg()
+    return _yom_kippur(_hebrew_year(year + 1)).to_greg().to_pydate()
 
 
 def sukkoth(year):
     """
     Return the Gregorian date for Sukkoth in the given Gregorian calendar year.
     """
-    return _sukkoth(_hebrew_year(year + 1)).to_greg()
+    return _sukkoth(_hebrew_year(year + 1)).to_greg().to_pydate()
 
 
 def simchat_torah(year):
@@ -205,7 +205,7 @@ def simchat_torah(year):
     Return the Gregorian date for Simchat Torah in the given Gregorian calendar
     year.
     """
-    return _simchat_torah(_hebrew_year(year + 1)).to_greg()
+    return _simchat_torah(_hebrew_year(year + 1)).to_greg().to_pydate()
 
 
 def _is_normalized(dt):

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -139,15 +139,15 @@ def memorial_day(year):
     d = _memorial_day(_hebrew_year(year)).to_greg()
 
     # Reschedule to avoid Sabbath desecration, maybe.
-    if d.isoweekday() == 4:
+    if d.weekday() == 5:
         # Falls on a Thursday, so Independency Day falls on the Friday.
         # Moved down by one day.
         return d - 1
-    elif d.isoweekday() == 5:
+    elif d.weekday() == 6:
         # Falls on a Friday, so Independence Day falls on the Saturday.
         # Moved down by two days.
         return d - 2
-    elif d.isoweekday() == 6:
+    elif d.weekday() == 7:
         # Falls on a Saturday, therefore moved up by one day.
         return d + 1
     else:
@@ -170,7 +170,7 @@ def fast_day(year):
     d = _fast_day(_hebrew_year(year)).to_greg()
 
     # Reschedule if it falls on Sabbath (Saturday), maybe.
-    if d.isoweekday() == 6:
+    if d.weekday() == 7:
         # Falls on a Saturday, therefore moved up by one day.
         return d + 1
     else:

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -118,7 +118,7 @@ def purim(year):
     """
     Return the Gregorian date for Purim in the given Gregorian calendar year.
     """
-    return _purim(_hebrew_year(year)).to_greg().to_pydate()
+    return _purim(_hebrew_year(year)).to_greg()
 
 
 def passover(year):
@@ -126,7 +126,7 @@ def passover(year):
     Return the Gregorian date for the first day of Passover in the given
     Gregorian calendar year.
     """
-    return _passover(_hebrew_year(year)).to_greg().to_pydate()
+    return _passover(_hebrew_year(year)).to_greg()
 
 
 def memorial_day(year):
@@ -136,7 +136,7 @@ def memorial_day(year):
     """
 
     # Regular Memorial Day date.
-    d = _memorial_day(_hebrew_year(year)).to_greg().to_pydate()
+    d = _memorial_day(_hebrew_year(year)).to_greg()
 
     # Reschedule to avoid Sabbath desecration, maybe.
     if d.isoweekday() == 4:
@@ -159,7 +159,7 @@ def pentecost(year):
     Return the Gregorian date for Pentecost in the given Gregorian calendar
     year.
     """
-    return _pentecost(_hebrew_year(year)).to_greg().to_pydate()
+    return _pentecost(_hebrew_year(year)).to_greg()
 
 
 def fast_day(year):
@@ -167,7 +167,7 @@ def fast_day(year):
     Return the Gregorian date for Tisha B'Av in the given Gregorian calendar
     year.
     """
-    d = _fast_day(_hebrew_year(year)).to_greg().to_pydate()
+    d = _fast_day(_hebrew_year(year)).to_greg()
 
     # Reschedule if it falls on Sabbath (Saturday), maybe.
     if d.isoweekday() == 6:
@@ -182,7 +182,7 @@ def new_year(year):
     Return the Gregorian date for the first day of a new year in the given
     Gregorian calendar year.
     """
-    return _new_year(_hebrew_year(year + 1)).to_greg().to_pydate()
+    return _new_year(_hebrew_year(year + 1)).to_greg()
 
 
 def yom_kippur(year):
@@ -190,14 +190,14 @@ def yom_kippur(year):
     Return the Gregorian date for Yom Kippur in the given Gregorian calendar
     year.
     """
-    return _yom_kippur(_hebrew_year(year + 1)).to_greg().to_pydate()
+    return _yom_kippur(_hebrew_year(year + 1)).to_greg()
 
 
 def sukkoth(year):
     """
     Return the Gregorian date for Sukkoth in the given Gregorian calendar year.
     """
-    return _sukkoth(_hebrew_year(year + 1)).to_greg().to_pydate()
+    return _sukkoth(_hebrew_year(year + 1)).to_greg()
 
 
 def simchat_torah(year):
@@ -205,7 +205,7 @@ def simchat_torah(year):
     Return the Gregorian date for Simchat Torah in the given Gregorian calendar
     year.
     """
-    return _simchat_torah(_hebrew_year(year + 1)).to_greg().to_pydate()
+    return _simchat_torah(_hebrew_year(year + 1)).to_greg()
 
 
 def _is_normalized(dt):
@@ -233,7 +233,7 @@ class _HolidayOffset(Easter):
 
     @apply_wraps
     def apply(self, other):
-        current = self.holiday(other.year)
+        current = self.holiday(other.year).to_pydate()
         current = datetime(current.year, current.month, current.day)
         current = localize_pydatetime(current, other.tzinfo)
 
@@ -246,7 +246,7 @@ class _HolidayOffset(Easter):
 
         # NOTE: self.holiday a dates.GregorianDate so we have to convert to
         # type of other
-        new = self.holiday(other.year + n)
+        new = self.holiday(other.year + n).to_pydate()
         new = datetime(
             new.year,
             new.month,
@@ -261,7 +261,8 @@ class _HolidayOffset(Easter):
     def is_on_offset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
-        return date(dt.year, dt.month, dt.day) == self.holiday(dt.year)
+        return date(dt.year, dt.month, dt.day) \
+            == self.holiday(dt.year).to_pydate()
 
 
 # DateOffset subclasses for holidays observed by TASE.

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -5,12 +5,18 @@ from pandas.tseries.offsets import Easter
 
 try:
     from pandas._libs.tslibs.offsets import apply_wraps
+except ImportError:
+    from pandas.tseries.offsets import apply_wraps
+
+try:
     from pandas._libs.tslibs.conversion import localize_pydatetime
+except ImportError:
+    from pandas.tslib import _localize_pydatetime as localize_pydatetime
+
+try:
     from pandas._libs.tslibs.timestamps import _Timestamp
     HAVE_TIMESTAMP = True
-except Exception:
-    from pandas.tseries.offsets import apply_wraps
-    from pandas.tslib import _localize_pydatetime as localize_pydatetime
+except ImportError:
     HAVE_TIMESTAMP = False
 
 

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -14,7 +14,7 @@ from pandas._libs.tslibs.timestamps import _Timestamp
 # https://en.wikipedia.org/wiki/Hebrew_calendar.
 
 
-def _purim(year: hebrewcal.Year) -> dates.HebrewDate:
+def _purim(year):
     """
     Return the Hebrew date for Purim in the given Hebrew year.
     """
@@ -22,7 +22,7 @@ def _purim(year: hebrewcal.Year) -> dates.HebrewDate:
     return dates.HebrewDate(year.year, 13 if year.leap else 12, 14)
 
 
-def _passover(year: hebrewcal.Year) -> dates.HebrewDate:
+def _passover(year):
     """
     Return the Hebrew date for the first day of Passover in the given Hebrew
     year.
@@ -30,7 +30,7 @@ def _passover(year: hebrewcal.Year) -> dates.HebrewDate:
     return dates.HebrewDate(year.year, 1, 15)
 
 
-def _memorial_day(year: hebrewcal.Year) -> dates.HebrewDate:
+def _memorial_day(year):
     """
     Return the Hebrew date for Memorial Day in the given Hebrew year.
 
@@ -39,21 +39,21 @@ def _memorial_day(year: hebrewcal.Year) -> dates.HebrewDate:
     return dates.HebrewDate(year.year, 2, 4)
 
 
-def _pentecost(year: hebrewcal.Year) -> dates.HebrewDate:
+def _pentecost(year):
     """
     Return the Hebrew date for Pentecost in the given Hebrew year.
     """
     return dates.HebrewDate(year.year, 3, 6)
 
 
-def _fast_day(year: hebrewcal.Year) -> dates.HebrewDate:
+def _fast_day(year):
     """
     Return the Hebrew date for Tisha B'Av in the given Hebrew year.
     """
     return dates.HebrewDate(year.year, 5, 9)
 
 
-def _new_year(year: hebrewcal.Year) -> dates.HebrewDate:
+def _new_year(year):
     """
     Return the Hebrew date for the first day of a new year in the given Hebrew
     year.
@@ -61,28 +61,28 @@ def _new_year(year: hebrewcal.Year) -> dates.HebrewDate:
     return dates.HebrewDate(year.year, 7, 1)
 
 
-def _yom_kippur(year: hebrewcal.Year) -> dates.HebrewDate:
+def _yom_kippur(year):
     """
     Return the Hebrew date for Yom Kippur in the given Hebrew year.
     """
     return dates.HebrewDate(year.year, 7, 10)
 
 
-def _sukkoth(year: hebrewcal.Year) -> dates.HebrewDate:
+def _sukkoth(year):
     """
     Return the Hebrew date for Sukkoth in the given Hebrew year.
     """
     return dates.HebrewDate(year.year, 7, 15)
 
 
-def _simchat_torah(year: hebrewcal.Year) -> dates.HebrewDate:
+def _simchat_torah(year):
     """
     Return the Hebrew date for Simchat Torah in the given Hebrew year.
     """
     return dates.HebrewDate(year.year, 7, 22)
 
 
-def _hebrew_year(year: int) -> hebrewcal.Year:
+def _hebrew_year(year):
     """
     Return the Hebrew calendar year that corresponds to 1st January of the
     given Gregorian calendar year.
@@ -99,14 +99,14 @@ def _hebrew_year(year: int) -> hebrewcal.Year:
 # TASE for a given Gregorian calendar year. Adjustments are also applied.
 
 
-def purim(year: int) -> dates.GregorianDate:
+def purim(year):
     """
     Return the Gregorian date for Purim in the given Gregorian calendar year.
     """
     return _purim(_hebrew_year(year)).to_greg()
 
 
-def passover(year: int) -> dates.GregorianDate:
+def passover(year):
     """
     Return the Gregorian date for the first day of Passover in the given
     Gregorian calendar year.
@@ -114,7 +114,7 @@ def passover(year: int) -> dates.GregorianDate:
     return _passover(_hebrew_year(year)).to_greg()
 
 
-def memorial_day(year: int) -> dates.GregorianDate:
+def memorial_day(year):
     """
     Return the Gregorian date for Memorial Day in the given Gregorian calendar
     year.
@@ -139,7 +139,7 @@ def memorial_day(year: int) -> dates.GregorianDate:
         return d
 
 
-def pentecost(year: int) -> dates.GregorianDate:
+def pentecost(year):
     """
     Return the Gregorian date for Pentecost in the given Gregorian calendar
     year.
@@ -147,7 +147,7 @@ def pentecost(year: int) -> dates.GregorianDate:
     return _pentecost(_hebrew_year(year)).to_greg()
 
 
-def fast_day(year: int) -> dates.GregorianDate:
+def fast_day(year):
     """
     Return the Gregorian date for Tisha B'Av in the given Gregorian calendar
     year.
@@ -162,7 +162,7 @@ def fast_day(year: int) -> dates.GregorianDate:
         return d
 
 
-def new_year(year: int) -> dates.GregorianDate:
+def new_year(year):
     """
     Return the Gregorian date for the first day of a new year in the given
     Gregorian calendar year.
@@ -170,7 +170,7 @@ def new_year(year: int) -> dates.GregorianDate:
     return _new_year(_hebrew_year(year + 1)).to_greg()
 
 
-def yom_kippur(year: int) -> dates.GregorianDate:
+def yom_kippur(year):
     """
     Return the Gregorian date for Yom Kippur in the given Gregorian calendar
     year.
@@ -178,14 +178,14 @@ def yom_kippur(year: int) -> dates.GregorianDate:
     return _yom_kippur(_hebrew_year(year + 1)).to_greg()
 
 
-def sukkoth(year: int) -> dates.GregorianDate:
+def sukkoth(year):
     """
     Return the Gregorian date for Sukkoth in the given Gregorian calendar year.
     """
     return _sukkoth(_hebrew_year(year + 1)).to_greg()
 
 
-def simchat_torah(year: int) -> dates.GregorianDate:
+def simchat_torah(year):
     """
     Return the Gregorian date for Simchat Torah in the given Gregorian calendar
     year.
@@ -193,7 +193,7 @@ def simchat_torah(year: int) -> dates.GregorianDate:
     return _simchat_torah(_hebrew_year(year + 1)).to_greg()
 
 
-def _is_normalized(dt: datetime):
+def _is_normalized(dt):
     if dt.hour != 0 or dt.minute != 0 or dt.second != 0 or dt.microsecond != 0:
         # Regardless of whether dt is datetime vs Timestamp
         return False
@@ -216,7 +216,7 @@ class _HolidayOffset(Easter):
         pass
 
     @apply_wraps
-    def apply(self, other: datetime) -> datetime:
+    def apply(self, other):
         current = self.holiday(other.year)
         current = datetime(current.year, current.month, current.day)
         current = localize_pydatetime(current, other.tzinfo)
@@ -242,7 +242,7 @@ class _HolidayOffset(Easter):
         )
         return new
 
-    def is_on_offset(self, dt: datetime) -> bool:
+    def is_on_offset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
         return date(dt.year, dt.month, dt.day) == self.holiday(dt.year)

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -1,9 +1,18 @@
 from datetime import datetime, date
 from pyluach import dates, hebrewcal
 from pandas.tseries.holiday import Holiday, Day
-from pandas._libs.tslibs.offsets import apply_wraps, Easter
-from pandas._libs.tslibs.conversion import localize_pydatetime
-from pandas._libs.tslibs.timestamps import _Timestamp
+from pandas.tseries.offsets import Easter
+
+try:
+    from pandas._libs.tslibs.offsets import apply_wraps
+    from pandas._libs.tslibs.conversion import localize_pydatetime
+    from pandas._libs.tslibs.timestamps import _Timestamp
+    HAVE_TIMESTAMP = True
+except:
+    from pandas.tseries.offsets import apply_wraps
+    from pandas.tslib import _localize_pydatetime as localize_pydatetime
+    HAVE_TIMESTAMP = False
+
 
 # Auxiliary functions to get Hebrew dates for holidays observed by TASE for a
 # given Hebrew calendar year. These are just the raw dates with no adjustments
@@ -197,8 +206,9 @@ def _is_normalized(dt):
     if dt.hour != 0 or dt.minute != 0 or dt.second != 0 or dt.microsecond != 0:
         # Regardless of whether dt is datetime vs Timestamp
         return False
-    if isinstance(dt, _Timestamp):
-        return dt.nanosecond == 0
+    if HAVE_TIMESTAMP:
+        if isinstance(dt, _Timestamp):
+            return dt.nanosecond == 0
     return True
 
 

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -8,7 +8,7 @@ try:
     from pandas._libs.tslibs.conversion import localize_pydatetime
     from pandas._libs.tslibs.timestamps import _Timestamp
     HAVE_TIMESTAMP = True
-except ModuleNotFoundError:
+except Exception:
     from pandas.tseries.offsets import apply_wraps
     from pandas.tslib import _localize_pydatetime as localize_pydatetime
     HAVE_TIMESTAMP = False

--- a/trading_calendars/tase_holidays.py
+++ b/trading_calendars/tase_holidays.py
@@ -8,7 +8,7 @@ try:
     from pandas._libs.tslibs.conversion import localize_pydatetime
     from pandas._libs.tslibs.timestamps import _Timestamp
     HAVE_TIMESTAMP = True
-except:
+except ModuleNotFoundError:
     from pandas.tseries.offsets import apply_wraps
     from pandas.tslib import _localize_pydatetime as localize_pydatetime
     HAVE_TIMESTAMP = False


### PR DESCRIPTION
This PR adds proper rules for regular XTAE holidays as opposed to just having everything defined as ad-hoc holidays.

I've done my best to cross-check this against the official information here: https://info.tase.co.il/eng/about_tase/corporate/pages/vacation_schedule.aspx

One open point is that it seems that Shushan Purim (which is one day after Purim and is typically not observed in Tel Aviv, but e.g. Jerusalem) will be observed from 2022 on, but wasn't observed before. I'm waiting for clarification back from TASE on this point.

Nevertheless, the current version of the code is consistent with what is currently listed on the website at least for 2020 - 2023. I also briefly manually checked a few years before, but no unit tests are there for these yet.

On a technical note, I've re-used Pandas `Easter` class -- which is a subclass of `DateOffset` -- for all holidays since they likewise fall on different Gregorian dates every year. To be able to do that, I had to import a few (internal) Cython functions and classes. A pure Python or even Cython re-implementation seemed to risky in terms of likely forgetting to handle this or that corner-case. We just have to be aware of these imports since they may introduce some more coupling on the specific Pandas version used.

Let me know your thoughts...