### PR TITLE
Fix to NP_NAT calculation to broaden numpy support

### DIFF
--- a/trading_calendars/calendar_helpers.py
+++ b/trading_calendars/calendar_helpers.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 NANOSECONDS_PER_MINUTE = int(6e10)
 
-NP_NAT = np.array([pd.NaT], dtype=np.int64)[0]
+NP_NAT = np.frombuffer(np.datetime64('NaT').tobytes(),np.int64)[0]
 
 
 def next_divider_idx(dividers, minute_val):


### PR DESCRIPTION
Updated line NP_NAT to support more versions of numpy and removed Pandas requirement in calculation of constant NP_NAT

